### PR TITLE
Correção de bug que impedia o filtro de Strings com N caracteres

### DIFF
--- a/StatePicker/RNStatePickerViewController.m
+++ b/StatePicker/RNStatePickerViewController.m
@@ -265,11 +265,13 @@ static NSString *statePlistName = @"states";
     for (NSArray *section in _sections) {
         for (id<RNState> state in section)
         {
+            if ([[state stateName] length] >= [searchText length]) {
                 NSComparisonResult result = [state.stateName compare:searchText options:(NSCaseInsensitiveSearch|NSDiacriticInsensitiveSearch) range:NSMakeRange(0, [searchText length])];
                 if (result == NSOrderedSame)
                 {
                     [_filteredList addObject:state];
                 }
+            }
         }
     }
 }


### PR DESCRIPTION
Correção de bug que impedia o filtro de Strings com N caracteres.
Ex.: Pesquisar Minas fecha a aplicação, pois durante o filtro é necessário realizar a comparação com a string Acre e a mesma possui 4 caracteres e Minas 5